### PR TITLE
Fix: React modules cause an app crash

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ Share the steps to reproduce the issue, screenshots, or a [CodeSandbox](https://
 
 - Gravatar Hovercards version: [e.g. v1.0.0]
 - Browser: [e.g. Chrome, Safari]
-- Platform: [e.g. Windows, macOS, iOS, Android]
+- Platform: [e.g. Windows, MacOS, iOS, Android]
 
 ## Additional Information
 

--- a/webpack/config.playground.js
+++ b/webpack/config.playground.js
@@ -1,4 +1,3 @@
-const path = require( 'path' );
 const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
 
 const commonConfig = require( './config.common' );
@@ -16,11 +15,4 @@ module.exports = {
 			template: './playground/index.html',
 		} ),
 	],
-	resolve: {
-		...commonConfig.resolve,
-		alias: {
-			// To use the same React version as the one used by the playground
-			React: path.resolve( __dirname, '../node_modules/react' ),
-		},
-	},
 };

--- a/webpack/config.react.js
+++ b/webpack/config.react.js
@@ -9,8 +9,8 @@ const baseConfig = {
 		path: path.resolve( 'dist' ),
 	},
 	externals: {
-		react: 'React',
-		'react-dom': 'ReactDOM',
+		react: 'react',
+		'react-dom': 'react-dom',
 	},
 };
 
@@ -58,6 +58,10 @@ const umdConfig = {
 			type: 'umd',
 			umdNamedDefine: true,
 		},
+	},
+	externals: {
+		react: 'React',
+		'react-dom': 'ReactDOM',
 	},
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If there is no related issue, please create one first.
-->

Related to #4

## Proposed Changes

* Correct the `externals` field of the Webpack config for React modules

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* React modules should work well as below (fixing by replace the `React` with `react`):

https://github.com/gravatar/hovercards/assets/21308003/c3c73231-56f4-4c83-b87b-a4f09472d10a



